### PR TITLE
Fix keyboard input bugs

### DIFF
--- a/game/src/game/game.js
+++ b/game/src/game/game.js
@@ -172,20 +172,26 @@ Game.prototype.draw = function(c) {
 	c.fillText(text, this.width - 5 - c.measureText(text).width, this.height - 5);
 };
 
-Game.prototype.keyDown = function(keyCode) {
+Game.prototype.keyDown = function(e) {
+	var keyCode = e.which;
 	var action = Keys.fromKeyCode(keyCode);
 	if (action != null) {
 		if (action.indexOf('a-') == 0) gameState.playerA[action.substr(2)] = true;
 		else if (action.indexOf('b-') == 0) gameState.playerB[action.substr(2)] = true;
 		else gameState[action] = true;
+		e.preventDefault();
+		e.stopPropagation();
 	}
 };
 
-Game.prototype.keyUp = function(keyCode) {
+Game.prototype.keyUp = function(e) {
+	var keyCode = e.which;
 	var action = Keys.fromKeyCode(keyCode);
 	if (action != null) {
 		if (action.indexOf('a-') == 0) gameState.playerA[action.substr(2)] = false;
 		else if (action.indexOf('b-') == 0) gameState.playerB[action.substr(2)] = false;
 		else gameState[action] = false;
+		e.preventDefault();
+		e.stopPropagation();
 	}
 };

--- a/game/src/game/main.js
+++ b/game/src/game/main.js
@@ -257,7 +257,7 @@ Level.prototype.show = function() {
 
 Level.prototype.keyDown = function(e) {
 	if (this.game != null) {
-		this.game.keyDown(e.which);
+		this.game.keyDown(e);
 
 		if (e.which == SPACEBAR) {
 			if (gameState.gameStatus === GAME_LOST) {
@@ -279,7 +279,7 @@ Level.prototype.keyDown = function(e) {
 
 Level.prototype.keyUp = function(e) {
 	if (this.game != null) {
-		this.game.keyUp(e.which);
+		this.game.keyUp(e);
 	}
 };
 
@@ -377,6 +377,7 @@ $('.key.changeable').live('mousedown', function(e) {
 	$('.key.changing').removeClass('changing');
 	$('#' + keyToChange).addClass('changing');
 	e.preventDefault();
+	e.stopPropagation();
 });
 
 $(document).keydown(function(e) {
@@ -386,6 +387,7 @@ $(document).keydown(function(e) {
 		Keys.save();
 		$('#' + keyToChange).removeClass('changing');
 		e.preventDefault();
+		e.stopPropagation();
 		keyToChange = null;
 		return;
 	}
@@ -403,6 +405,7 @@ $(document).keydown(function(e) {
 		// Prevents default behaviors like scrolling up/down
 		if (e.which == UP_ARROW || e.which == DOWN_ARROW || e.which == SPACEBAR) {
 			e.preventDefault();
+			e.stopPropagation();
 		}
 	}
 });
@@ -416,6 +419,7 @@ $(document).keyup(function(e) {
 		// Prevents default behaviors like scrolling up/down
 		if (e.which == UP_ARROW || e.which == DOWN_ARROW || e.which == SPACEBAR) {
 			e.preventDefault();
+			e.stopPropagation();
 		}
 	}
 });


### PR DESCRIPTION
When using keyboard input, HTML5 apps need to call `e.preventDefault()` and `e.stopPropagation()` to keep key events from bubbling up to the browser and triggering built-in shortcuts. Particularly noticeable in browsers with typeahead find, where
pressing any key focuses the find-in-page search box.

To reproduce the bug without this patch (in any version of Firefox):
1. Open `about:config`.
2. Toggle `accessibility.typeaheadfind` to `true`.
3. Open [RAPT](http://raptjs.com) and try using W/A/S/D. Typeahead find will steal focus after the first keydown, absorbing all further keydown events and making the game unplayable.
